### PR TITLE
fix validation logic

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -45,11 +45,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   </section>
 
   <section>
-    <h4>Required input</h4>
-    <gold-cc-cvc-input required></gold-cc-cvc-input>
-
     <h4>Auto-validating input</h4>
-    <gold-cc-cvc-input auto-validate></gold-cc-cvc-input>
+    <gold-cc-cvc-input required auto-validate></gold-cc-cvc-input>
 
     <h4>With custom error message</h4>
     <gold-cc-cvc-input required error-message="Please enter a valid CVC"></gold-cc-cvc-input>

--- a/gold-cc-cvc-input.html
+++ b/gold-cc-cvc-input.html
@@ -51,7 +51,7 @@ Example:
       <div class="horizontal layout">
         <input is="iron-input" id="input" class="flex"
             bind-value="{{value}}"
-            prevent-invalid-input pattern="[0-9]*"
+            prevent-invalid-input allowed-pattern="[0-9]"
             required$="[[required]]"
             type="tel"
             maxlength$="[[_requiredLength]]">
@@ -106,8 +106,12 @@ Example:
       'input': '_onInput'
     },
 
+    ready: function() {
+      this._onInput();
+    },
+
     _onInput: function() {
-      this.$.container._inputIsInvalid = this.autoValidate &&
+      this.$.container.invalid = this.autoValidate &&
                                          this.value.length != this._requiredLength;
     },
 

--- a/test/basic.html
+++ b/test/basic.html
@@ -69,7 +69,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         forceXIfStamp(input);
         var container = Polymer.dom(input.root).querySelector('paper-input-container');
         assert.ok(container, 'paper-input-container exists');
-        assert.isFalse(container._inputIsInvalid);
+        assert.isFalse(container.invalid);
       });
 
       test('invalid input is not ok', function() {
@@ -79,7 +79,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         forceXIfStamp(input);
         var container = Polymer.dom(input.root).querySelector('paper-input-container');
         assert.ok(container, 'paper-input-container exists');
-        assert.isTrue(container._inputIsInvalid);
+        assert.isTrue(container.invalid);
       });
 
       test('empty required input shows error', function() {


### PR DESCRIPTION
Catches up to dependency changes:
- the `paper-input-container` invalid property was renamed
- there's a new `allowed-pattern` on `iron-input`