### PR TITLE
ff and ie fixes

### DIFF
--- a/gold-cc-cvc-input.html
+++ b/gold-cc-cvc-input.html
@@ -40,7 +40,6 @@ Example:
 
   iron-icon {
     margin-left: 10px;
-    margin-bottom: 3px;
   }
   </style>
 
@@ -58,10 +57,11 @@ Example:
             required$="[[required]]"
             type="tel"
             maxlength$="[[_requiredLength]]"
+            autocomplete$="[[autocomplete]]"
             name$="[[name]]">
 
-        <iron-icon id="icon" src="cvc_hint.png" hidden="[[amex]]"></iron-icon>
-        <iron-icon id="amexIcon" hidden="[[!amex]]" src="cvc_hint_amex.png"></iron-icon>
+        <iron-icon id="icon" src="cvc_hint.png" hidden$="[[amex]]" alt="cvc"></iron-icon>
+        <iron-icon id="amexIcon" hidden$="[[!amex]]" src="cvc_hint_amex.png" alt="amex cvc"></iron-icon>
       </div>
 
       <template is="dom-if" if="[[errorMessage]]">


### PR DESCRIPTION
This fixes:
- `hidden` wasn't working in IE 
- inputs have a min width in Firefox, which pushes the icon out
- NVDA on Firefox reads "autocomplete" if the attribute isn't set 
- added an `alt` text to the icons 