### PR TITLE
add autocomplete field

### DIFF
--- a/gold-cc-cvc-input.html
+++ b/gold-cc-cvc-input.html
@@ -77,7 +77,7 @@ style this element.
             required$="[[required]]"
             type="tel"
             maxlength$="[[_requiredLength]]"
-            autocomplete$="[[autocomplete]]"
+            autocomplete="cc-csc"
             name$="[[name]]">
 
         <iron-icon id="icon" src="cvc_hint.png" hidden$="[[amex]]" alt="cvc"></iron-icon>


### PR DESCRIPTION
Apparently the `autocomplete` field has meaning. See: https://developers.google.com/web/fundamentals/input/form/label-and-name-inputs?hl=en

It worked by magic in some of the elements because they had a heuristic-approved name in the demo, but now it works regardless of the name.

/cc @morethanreal @cdata 
