### PR TITLE
fix card type property

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,24 @@
 # gold-cc-cvc-input
 
-`gold-cc-cvc-input` is a Material Design field for entering a Credit Card's CVC
-number. It supports both Amex and non-Amex CVCs.
-
-Example:
+`gold-cc-cvc-input` is a single-line text field with Material Design styling
+for entering a credit card's CVC (Card Verification Code). It supports both
+4-digit Amex CVCs and non-Amex 3-digit CVCs.
 
 ```html
-<gold-cc-cvc-input label="CVC"></gold-cc-cvc-input>
+    <gold-cc-cvc-input></gold-cc-cvc-input>
 
-<gold-cc-cvc-input amex></gold-cc-cvc-input>
+    <gold-cc-cvc-input card-type="amex"></gold-cc-cvc-input>
+```
+
+It may include an optional label, which by default is "CVC".
+
+```html
+    <gold-cc-cvc-input label="Card Verification Value"></gold-cc-cvc-input>
+```
+
+It can be used together with a `gold-cc-input` by binding the `cardType` property:
+
+```html
+    <gold-cc-input card-type="{{cardType}}"></gold-cc-input>
+    <gold-cc-cvc-input card-type="[[cardType]]"></gold-cc-cvc-input>
 ```

--- a/demo/index.html
+++ b/demo/index.html
@@ -35,14 +35,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <h4>Standard</h4>
     <div class="vertical-section layout horizontal">
         <gold-cc-cvc-input class="small"></gold-cc-cvc-input>
-        <gold-cc-cvc-input class="small" label="AMEX" amex></gold-cc-cvc-input>
+        <gold-cc-cvc-input class="small" label="AMEX" card-type="amex"></gold-cc-cvc-input>
         <gold-cc-cvc-input auto-validate label="Auto"></gold-cc-cvc-input>
     </div>
 
     <h4>Pre-validated</h4>
     <div class="vertical-section  layout horizontal">
       <gold-cc-cvc-input required auto-validate value="123"></gold-cc-cvc-input>
-      <gold-cc-cvc-input required auto-validate amex value="1234"></gold-cc-cvc-input>
+      <gold-cc-cvc-input required auto-validate card-type="amex" value="1234"></gold-cc-cvc-input>
       <gold-cc-cvc-input required auto-validate value="12"></gold-cc-cvc-input>
     </div>
 

--- a/gold-cc-cvc-input.html
+++ b/gold-cc-cvc-input.html
@@ -23,11 +23,16 @@ for entering a credit card's CVC (Card Verification Code). It supports both
 
     <gold-cc-cvc-input></gold-cc-cvc-input>
 
-    <gold-cc-cvc-input amex></gold-cc-cvc-input>
+    <gold-cc-cvc-input card-type="amex"></gold-cc-cvc-input>
 
 It may include an optional label, which by default is "CVC".
 
     <gold-cc-cvc-input label="Card Verification Value"></gold-cc-cvc-input>
+
+It can be used together with a `gold-cc-input` by binding the `cardType` property:
+
+    <gold-cc-input card-type="{{cardType}}"></gold-cc-input>
+    <gold-cc-cvc-input card-type="[[cardType]]"></gold-cc-cvc-input>
 
 ### Validation
 
@@ -91,8 +96,8 @@ style this element.
             readonly$="[[readonly]]"
             size$="[[size]]">
 
-        <iron-icon id="icon" src="cvc_hint.png" hidden$="[[amex]]" alt="cvc"></iron-icon>
-        <iron-icon id="amexIcon" hidden$="[[!amex]]" src="cvc_hint_amex.png" alt="amex cvc"></iron-icon>
+        <iron-icon id="icon" src="cvc_hint.png" hidden$="[[_amex]]" alt="cvc"></iron-icon>
+        <iron-icon id="amexIcon" hidden$="[[!_amex]]" src="cvc_hint_amex.png" alt="amex cvc"></iron-icon>
       </div>
 
       <template is="dom-if" if="[[errorMessage]]">
@@ -120,16 +125,21 @@ style this element.
       },
 
       /**
-       * Set to true if the card that the CVC is for is an AMEX.
+       * The type of card that the CVC is for.
        */
-      amex: {
-        type: Boolean,
-        value: false
+      cardType: {
+        type: String,
+        value: ''
       },
 
       _requiredLength: {
         type: Number,
-        computed: '_computeRequiredLength(amex)'
+        computed: '_computeRequiredLength(cardType)'
+      },
+
+      _amex: {
+        type: Boolean,
+        computed: '_computeIsAmex(cardType)'
       }
     },
 
@@ -152,8 +162,12 @@ style this element.
       }
     },
 
-    _computeRequiredLength: function(amex) {
-      return this.amex ? 4 : 3;
+    _computeRequiredLength: function(cardType) {
+      return this._computeIsAmex(cardType) ? 4 : 3;
+    },
+
+    _computeIsAmex: function(cardType) {
+      return cardType.toLowerCase() == 'amex';
     },
 
     validate: function() {

--- a/test/basic.html
+++ b/test/basic.html
@@ -38,7 +38,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <test-fixture id="amex">
     <template>
-      <gold-cc-cvc-input amex required error-message="error"></gold-cc-cvc-input>
+      <gold-cc-cvc-input card-type="amex" required error-message="error"></gold-cc-cvc-input>
     </template>
   </test-fixture>
 


### PR DESCRIPTION
Fixes https://github.com/PolymerElements/gold-cc-cvc-input/issues/20 by allowing easier binding to a `gold-cc-input`'s `cardType` property