### PR TITLE
stop bringing in the paper-styles kitchen sink

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,6 +22,7 @@
   "ignore": [],
   "dependencies": {
     "iron-icon": "PolymerElements/iron-icon#^1.0.0",
+    "iron-flex-layout": "PolymerElements/iron-flex-layout#^1.0.0",
     "iron-form-element-behavior": "PolymerElements/iron-form-element-behavior#^1.0.0",
     "paper-input": "PolymerElements/paper-input#^1.0.0",
     "paper-styles": "PolymerElements/paper-styles#^1.0.0",
@@ -31,7 +32,7 @@
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
     "iron-test-helpers": "PolymerElements/iron-test-helpers#^1.0.0",
     "test-fixture": "PolymerElements/test-fixture#^1.0.0",
-    "web-component-tester": "*",
+    "web-component-tester": "polymer/web-component-tester#^3.4.0",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"
   }
 }

--- a/demo/index.html
+++ b/demo/index.html
@@ -19,28 +19,31 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
   <link rel="import" href="../gold-cc-cvc-input.html">
-
-  <link rel="stylesheet" href="../../paper-styles/paper-styles.html">
   <link rel="import" href="../../paper-styles/demo-pages.html">
+  <link rel="import" href="../../iron-flex-layout/iron-flex-layout.html">
 </head>
-<style>
+<style is="custom-style">
   gold-cc-cvc-input {
     width: 80px;
     margin-left: auto;
     margin-right: auto;
   }
+
+  .vertical-section {
+    @apply(--layout-horizontal);
+  }
 </style>
 <body unresolved>
   <div class="vertical-section-container centered">
     <h4>Standard</h4>
-    <div class="vertical-section layout horizontal">
+    <div class="vertical-section">
         <gold-cc-cvc-input class="small"></gold-cc-cvc-input>
         <gold-cc-cvc-input class="small" label="AMEX" card-type="amex"></gold-cc-cvc-input>
         <gold-cc-cvc-input auto-validate required label="Auto"></gold-cc-cvc-input>
     </div>
 
     <h4>Pre-validated</h4>
-    <div class="vertical-section  layout horizontal">
+    <div class="vertical-section">
       <gold-cc-cvc-input required auto-validate value="123"></gold-cc-cvc-input>
       <gold-cc-cvc-input required auto-validate card-type="amex" value="1234"></gold-cc-cvc-input>
       <gold-cc-cvc-input required auto-validate value="12"></gold-cc-cvc-input>

--- a/gold-cc-cvc-input.html
+++ b/gold-cc-cvc-input.html
@@ -14,7 +14,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../iron-input/iron-input.html">
 <link rel="import" href="../iron-icon/iron-icon.html">
 <link rel="import" href="../iron-form-element-behavior/iron-form-element-behavior.html">
-<link rel="import" href="../iron-flex-layout/classes/iron-flex-layout.html">
+<link rel="import" href="../iron-flex-layout/iron-flex-layout.html">
 
 <!--
 `gold-cc-cvc-input` is a single-line text field with Material Design styling
@@ -66,6 +66,14 @@ style this element.
   iron-icon {
     margin-left: 10px;
   }
+
+  .container {
+    @apply(--layout-horizontal);
+  }
+
+  input {
+    @apply(--layout-flex);
+  }
   </style>
 
   <template>
@@ -77,8 +85,8 @@ style this element.
 
       <label hidden$="[[!label]]">[[label]]</label>
 
-      <div class="horizontal layout">
-        <input is="iron-input" id="input" class="flex"
+      <div class="container">
+        <input is="iron-input" id="input"
             aria-labelledby$="[[_ariaLabelledBy]]"
             aria-describedby$="[[_ariaDescribedBy]]"
             bind-value="{{value}}"

--- a/test/basic.html
+++ b/test/basic.html
@@ -20,12 +20,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
 
   <script src="../../web-component-tester/browser.js"></script>
-  <script src="../../test-fixture/test-fixture-mocha.js"></script>
 
   <script src="../../iron-test-helpers/test-helpers.js"></script>
   <script src="../../iron-test-helpers/mock-interactions.js"></script>
 
-  <link rel="import" href="../../test-fixture/test-fixture.html">
   <link rel="import" href="../gold-cc-cvc-input.html">
 
 </head>


### PR DESCRIPTION
Fixes the generic usage of `paper-styles.html` and `/deep/` classes and uses the specific imports instead. Also updates the test to the new `wct#^3.4.0` way