### PR TITLE
Fixes #44 by invoking validate() on internal input field

### DIFF
--- a/gold-cc-cvc-input.html
+++ b/gold-cc-cvc-input.html
@@ -70,7 +70,7 @@ style this element.
       iron-icon[hidden] {
         display: none !important;
       }
-      
+
       .container {
         @apply(--layout-horizontal);
       }
@@ -199,11 +199,10 @@ style this element.
          */
         validate: function() {
           // Empty, non-required input is valid.
-          if (!this.required && this.value == '') {
-            return true;
-          }
-
-          var valid = this.value.length == this._requiredLength;
+          var valid =
+              (this.$.input.validate() &&
+              this.value.length == this._requiredLength) ||
+              !this.required && this.value == '';
 
           // Update the container and its addons (i.e. the custom error-message).
           this.$.container.invalid = !valid;

--- a/test/basic.html
+++ b/test/basic.html
@@ -93,6 +93,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var input = fixture('required');
         forceXIfStamp(input);
 
+        var container = Polymer.dom(input.root).querySelector('paper-input-container');
+        assert.ok(container, 'paper-input-container exists');
+        assert.isFalse(container.invalid);
+
         var error = Polymer.dom(input.root).querySelector('paper-input-error');
         assert.ok(error, 'paper-input-error exists');
 
@@ -100,6 +104,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         MockInteractions.focus(input);
         MockInteractions.blur(input);
 
+        assert.isTrue(container.invalid);
         assert.notEqual(getComputedStyle(error).visibility, 'hidden', 'error is not visibility:hidden');
       });
 


### PR DESCRIPTION
This fixes issue 44, by making the input field validate itself, which ultimately updates all of that fancy visual decoration.

(Take 2!)